### PR TITLE
refactor(app): change function name

### DIFF
--- a/src/cli/commands/createVue.ts
+++ b/src/cli/commands/createVue.ts
@@ -1,7 +1,7 @@
 import { UserInput } from "../config";
 import resolvePacakgeManager from "../../utils/resolvePackageManager";
 
-function createReactCommand(input: UserInput) {
+function createVueCommand(input: UserInput) {
   const { packageManager, appConfig, projectName } = input;
 
   const parts: string[] = [resolvePacakgeManager(packageManager)];
@@ -17,4 +17,4 @@ function createReactCommand(input: UserInput) {
   return parts.join(" ");
 }
 
-export default createReactCommand;
+export default createVueCommand;


### PR DESCRIPTION
This pull request is intended to rename the `createReactCommand` function in the `createVue.ts` file to `createVueCommand` to accurately represent the purpose of the function, which is to create a Vue project.